### PR TITLE
SRCH-497 ignore gh-pages branch in CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,11 @@
 version: 2
 jobs:
   build:
+    branches:
+      ignore:
+        # gh-pages is auto-updated by the 'deploy' rake task
+        - gh-pages
+
     docker:
        - image: circleci/ruby:2.3.8-node-browsers
 


### PR DESCRIPTION
@peggles2 / @dawnpm , the purpose of this PR is to prevent CircleCi from testing the `gh-pages` branch, which is updated automatically by the `deploy` rake task.  I have also set up a branch protection rule blocking any users other than our automated `dgsearchdev` user from updating that branch. 

The `deploy` task compiles the pages, sitemap, etc., and pushes those changes to the `gh-pages` branch. I can put in a story to investigate simplifying that process, but these changes should suffice for now.