### PR TITLE
SRCH-497 add CircleCi config to gh_pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2
+
+jobs:
+  build:
+    branches:
+      ignore:
+        # gh-pages is auto-updated by the 'deploy' rake task.
+        # This config exists just to keep CircleCi from reporting a lack thereof.
+        - gh-pages
+    docker:
+      - image: circleci/ruby:2.3.8-node-browsers
+
+    steps:
+      - checkout


### PR DESCRIPTION
This PR adds a bare-bones CircleCi config to the `gh-pages` branch. The config on master isn't usable on `gh-pages`, as `gh-pages` is missing many of the files used in testing, such as a Gemfile. The `gh-pages` branch can be skipped in CircleCi, as it is generated at the time of deployment. 
https://cm-jira.usa.gov/browse/SRCH-498 has been filed to simplify the branches and deployment of this repo.